### PR TITLE
explicitly set advertised.listeners using an IP address

### DIFF
--- a/etc/kafka/server.properties.auth
+++ b/etc/kafka/server.properties.auth
@@ -3,6 +3,7 @@
 ###
 broker.id=0
 listeners=SASL_SSL://:9092
+ADVERTISED_LISTENERS
 
 num.network.threads=3
 num.io.threads=8

--- a/etc/kafka/server.properties.no_auth
+++ b/etc/kafka/server.properties.no_auth
@@ -3,6 +3,7 @@
 ###
 broker.id=0
 listeners=PLAINTEXT://:9092
+ADVERTISED_LISTENERS
 
 num.network.threads=3
 num.io.threads=8

--- a/scripts/KafkaServer.py
+++ b/scripts/KafkaServer.py
@@ -174,6 +174,8 @@ class Config:
                   ";\n"
         keyCertPasswords = ("ssl.truststore.password=%s\nssl.keystore.password=%s\nssl.key.password="
                             "%s\n") % (self.pwd, self.pwd, self.pwd)
+        addr = socket.gethostbyname(socket.getfqdn())
+        al   = "advertised.listeners"
         if self.noSec:
             kcIn = open(self.kcTemplateNA, "r")
             while True:
@@ -181,6 +183,7 @@ class Config:
                 if line == '':
                     kcIn.close()
                     break
+                line = re.sub('(ADVERTISED_LISTENERS)', "%s=PLAINTEXT://%s:9092" % (al, addr), line)
                 kcOut.write(line)
         else:
             kcIn = open(self.kcTemplate, "r")
@@ -191,5 +194,6 @@ class Config:
                     break
                 line = re.sub('(KAFKA_CREDENTIALS)', uCreds, line)
                 line = re.sub('(SSL_KEY_CERT_PASSWORDS)', keyCertPasswords, line)
+                line = re.sub('(ADVERTISED_LISTENERS)', "%s=SASL_SSL://%s:9092" % (al, addr), line)
                 kcOut.write(line)
         kcOut.close()

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -51,7 +51,14 @@ class ServerContainer (multiprocessing.Process):
         print("COMMAND: %s" % " ".join([self.cmd] + self.args))
         child = subprocess.Popen([self.cmd] + self.args)
         child.wait()
-                    
+
+    def ipAddr (self):
+        format = "'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'"
+        cmd = "docker inspect --format=%s %s" % (format, self.name)
+        line = subprocess.Popen([cmd], shell=True,
+                                stdout=subprocess.PIPE).stdout.read().decode().splitlines()[0]
+        return line.rstrip()
+
     def runClientCommand (self, cmd, opts=[]):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s" % self.network
         command += " %s %s %s </dev/null" %  (" ".join(opts), self.cimage, cmd)

--- a/test/test_sec.py
+++ b/test/test_sec.py
@@ -1,4 +1,5 @@
 import TestUtils as tu
+import re
 
 def setup_module (module):
     global server
@@ -12,6 +13,19 @@ def teardown_module (module):
 
 def test_kafkaRunning ():
     assert(server.kafkaIsRunning())
+
+def test_expectedListenIP ():
+    expected = "broker 0 at %s:9092" % server.ipAddr()
+    print("expected: \"%s\"" % expected)
+    command  = "kafkacat -L -b %s" % server.brokerString()
+    lines    = server.runClientCommandWithOutput(command)
+    matched  = False
+    for line in lines:
+        print("matching line: \"%s\"" % line)
+        if line.find(expected) > -1:
+            matched = True
+            break
+    assert(matched)
 
 def test_publish ():
     command = "kafkacat -P -b %s -t test" % server.brokerString()


### PR DESCRIPTION
This pull request addresses #45.

The IP of the host is used instead of the hostname of the host.
