### PR TITLE
update doc, tests, client Dockerfile to use hop 0.0.5 and hop subscribe

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -6,7 +6,7 @@ RUN cd /usr/local/src && \
     python3 setup.py build  && \
     python3 setup.py install  
 RUN mkdir -p /root/.config && ln -s /root/shared/kafkacat.conf /root/.config/kafkacat.conf
-RUN pip3 install scimma-client==0.0.4
+RUN pip3 install hop-client==0.0.5
 RUN mkdir -p /root/test_data
 COPY test/data/example.gcn3 /root/test_data/example.gcn3
 WORKDIR /usr/bin

--- a/doc/QuickDemo.md
+++ b/doc/QuickDemo.md
@@ -14,8 +14,8 @@ docker run -i --rm=true --network=scimma-net -v shared:/root/shared scimma/clien
 docker run -i --rm=true --network=scimma-net -v shared:/root/shared scimma/client:latest kafkacat -L -b scimma-server:9092
 docker run -i --rm=true --network=scimma-net -v shared:/root/shared scimma/client:latest kafkacat -C -b scimma-server:9092 -t test -e
 
-docker run -i --rm=true --network=scimma-net -v shared:/root/shared scimma/client:latest scimma publish  -F /root/shared/kafkacat.conf  -b kafka://scimma-server:9092/gcn /root/test_data/example.gcn3
-docker run -i --rm=true --network=scimma-net -v shared:/root/shared scimma/client:latest kafkacat -C -b scimma-server:9092 -t gcn -e
+docker run -i --rm=true --network=scimma-net -v shared:/root/shared scimma/client:latest hop publish -F /root/shared/kafkacat.conf kafka://scimma-server:9092/gcn /root/test_data/example.gcn3
+docker run -i --rm=true --network=scimma-net -v shared:/root/shared scimma/client:latest hop subscribe -F /root/shared/kafkacat.conf -e kafka://scimma-server:9092/gcn
 
 docker kill scimma-server
 docker network rm scimma-net
@@ -117,20 +117,20 @@ the command:
 
 ### Publish a GCN
 ```
-docker run -i --network=scimma-net -v shared:/root/shared scimma/client:latest scimma publish  -F /root/shared/kafkacat.conf  -b kafka://scimma-server:9092/gcn /root/test_data/example.gcn3
+docker run -i --network=scimma-net -v shared:/root/shared scimma/client:latest hop publish -F /root/shared/kafkacat.conf kafka://scimma-server:9092/gcn /root/test_data/example.gcn3
 ```
 
-This command runs the scimma command in a container. The file ``example.gcn3`` is included as part of the container. You could mount a local directory
+This command runs the ``hop`` command in a container. The file ``example.gcn3`` is included as part of the container. You could mount a local directory
 containing GCNs as a volume in the client container and have the scimma client read files there.
 
 Note that the Kafka topic, ``gcn``, is specified as part of the URL.
 
 ### Read the GCN
 ```
-docker run -i --network=scimma-net -v shared:/root/shared scimma/client:latest kafkacat -C -b scimma-server:9092 -t gcn -e
+docker run -i --network=scimma-net -v shared:/root/shared scimma/client:latest hop subscribe -F /root/shared/kafkacat.conf -e kafka://scimma-server:9092/gcn
 ```
 
-This uses ``kafkacat`` in the client container to read the ``gcn`` topic.
+This uses ``hop`` in the client container to read the ``gcn`` topic.
 
 ### Clean Up
 

--- a/test/test_sec.py
+++ b/test/test_sec.py
@@ -67,6 +67,10 @@ def test_scimmaPublishGCN ():
     cnf = "/root/shared/kafkacat.conf"
     brk = "kafka://%s/gcn" % server.brokerString()
     gcn = "/root/test_data/example.gcn3"
-    command = "scimma publish -F %s -b %s %s" % (cnf, brk, gcn)
+    command = "hop publish -F %s %s %s" % (cnf, brk, gcn)
     assert(server.runClientCommand(command) == 0)
 
+def test_scimmaSubscribeGCN ():
+    cnf = "/root/shared/kafkacat.conf"
+    brk = "kafka://%s/gcn" % server.brokerString()
+    command = "hop subscribe -F %s -e %s" % (cnf, brk)


### PR DESCRIPTION
This PR updates the client container to install hop-client v0.0.5, as well as updates the docs and tests to use `hop subscribe` as well.

I wasn't able to get the tests to pass locally but I was unsure whether that was a problem with how docker is configured on my laptop.