### PR TITLE
Update for hop-client 0.1, including writing a config.toml file for auth

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -6,7 +6,8 @@ RUN cd /usr/local/src && \
     python3 setup.py build  && \
     python3 setup.py install  
 RUN mkdir -p /root/.config && ln -s /root/shared/kafkacat.conf /root/.config/kafkacat.conf
-RUN pip3 install hop-client==0.0.5
+RUN ln -s /root/shared/config.toml /root/.config/config.toml
+RUN pip3 install hop-client==0.1
 RUN mkdir -p /root/test_data
 COPY test/data/example.gcn3 /root/test_data/example.gcn3
 WORKDIR /usr/bin

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -4,7 +4,8 @@ RUN cd /usr/local/src && \
     cd confluent-kafka-python && \
     git checkout v1.3.0 && \
     python3 setup.py build  && \
-    python3 setup.py install  
+    python3 setup.py install
+RUN yum install -y python2-toml
 RUN mkdir -p /root/.config && ln -s /root/shared/kafkacat.conf /root/.config/kafkacat.conf
 RUN pip3 install hop-client==0.1
 RUN mkdir -p /root/test_data

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -5,10 +5,11 @@ RUN cd /usr/local/src && \
     git checkout v1.3.0 && \
     python3 setup.py build  && \
     python3 setup.py install
-RUN yum install -y python2-toml
 RUN mkdir -p /root/.config && ln -s /root/shared/kafkacat.conf /root/.config/kafkacat.conf
+RUN mkdir -p /root/.config/hop && ln -s /root/shared/config.toml /root/.config/hop/config.toml
 RUN pip3 install hop-client==0.1
 RUN mkdir -p /root/test_data
 COPY test/data/example.gcn3 /root/test_data/example.gcn3
+ENV XDG_CONFIG_PATH /root
 WORKDIR /usr/bin
 CMD ["/bin/bash"]

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -6,7 +6,6 @@ RUN cd /usr/local/src && \
     python3 setup.py build  && \
     python3 setup.py install  
 RUN mkdir -p /root/.config && ln -s /root/shared/kafkacat.conf /root/.config/kafkacat.conf
-RUN ln -s /root/shared/config.toml /root/.config/config.toml
 RUN pip3 install hop-client==0.1
 RUN mkdir -p /root/test_data
 COPY test/data/example.gcn3 /root/test_data/example.gcn3

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -7,6 +7,7 @@ COPY scripts/KafkaServer.py /root/KafkaServer.py
 COPY scripts/kafka-run-class.java_debug /usr/bin/kafka-run-class.java_debug
 RUN  chmod ugo+rx /root/runServer /usr/bin/kafka-run-class
 RUN  mkdir -p /root/shared/tls
+RUN yum install -y python36-toml
 WORKDIR /tmp
 EXPOSE 9092/tcp
 ENTRYPOINT ["/root/runServer"]

--- a/scripts/KafkaServer.py
+++ b/scripts/KafkaServer.py
@@ -178,7 +178,7 @@ class Config:
                     "username": username,
                     "password": password,
                     "mechanism": "PLAIN",
-                    "ssl_ca_location": self.tlsDir
+                    "ssl_ca_location": "%s/cacert.pem" % self.tlsDir
                 }
             }
             with open(self.hopConfig, "w") as f:

--- a/scripts/KafkaServer.py
+++ b/scripts/KafkaServer.py
@@ -82,7 +82,7 @@ class Command(multiprocessing.Process):
 class Config:
 
     kcConfig     = "/root/shared/kafkacat.conf"
-    hopConfig    = "/root/shared/.config/hop/config.toml"
+    hopConfig    = "/root/shared/config.toml"
     kcTemplate   = "/etc/kafka/server.properties.auth"
     kcTemplateNA = "/etc/kafka/server.properties.no_auth"
     kConfig      = "/etc/kafka/server.properties"

--- a/scripts/KafkaServer.py
+++ b/scripts/KafkaServer.py
@@ -174,10 +174,12 @@ class Config:
         if not self.noSec:
             username, password = self.ul.split(',')[0].split(':')
             config = {
-                "username": username,
-                "password": password,
-                "mechanism": "PLAIN",
-                "ssl_ca_location": self.tlsDir
+                "auth": {
+                    "username": username,
+                    "password": password,
+                    "mechanism": "PLAIN",
+                    "ssl_ca_location": self.tlsDir
+                }
             }
             with open(self.hopConfig, "w") as f:
                 toml.dump(config, f)

--- a/scripts/KafkaServer.py
+++ b/scripts/KafkaServer.py
@@ -82,7 +82,7 @@ class Command(multiprocessing.Process):
 class Config:
 
     kcConfig     = "/root/shared/kafkacat.conf"
-    hopConfig    = "/root/shared/config.toml"
+    hopConfig    = "/root/shared/.config/hop/config.toml"
     kcTemplate   = "/etc/kafka/server.properties.auth"
     kcTemplateNA = "/etc/kafka/server.properties.no_auth"
     kConfig      = "/etc/kafka/server.properties"
@@ -176,7 +176,7 @@ class Config:
             config = {
                 "username": username,
                 "password": password,
-                "mechanism": "SASL_SSL",
+                "mechanism": "PLAIN",
                 "ssl_ca_location": self.tlsDir
             }
             with open(self.hopConfig, "w") as f:

--- a/scripts/KafkaServer.py
+++ b/scripts/KafkaServer.py
@@ -7,6 +7,8 @@ import os
 import sys
 import signal as sig
 
+import toml
+
 def getHostnames ():
     cmd   = "ip -4 -o address"
     lines = subprocess.Popen([cmd], shell=True,
@@ -80,6 +82,7 @@ class Command(multiprocessing.Process):
 class Config:
 
     kcConfig     = "/root/shared/kafkacat.conf"
+    hopConfig    = "/root/shared/config.toml"
     kcTemplate   = "/etc/kafka/server.properties.auth"
     kcTemplateNA = "/etc/kafka/server.properties.no_auth"
     kConfig      = "/etc/kafka/server.properties"
@@ -100,6 +103,7 @@ class Config:
     def write (self):
        self.writeSSLConfig()
        self.writeKafkacatConfig()
+       self.writeHopConfig()
        self.writeKafkaConfig()
        if self.jDbg:
            os.system("cp %s %s" % (self.krcDbg, self.krc))
@@ -160,12 +164,23 @@ class Config:
         f.close()
 
     def writeKafkacatConfig (self):
-        f = open(self.kcConfig, "w")
         if not self.noSec:
-            f.write("ssl.ca.location=%s/cacert.pem\nsecurity.protocol=SASL_SSL\n"
-                    "sasl.mechanism=PLAIN\nsasl.username=%s\nsasl.password="
-                    "%s\n" % tuple([self.tlsDir] + self.ul.split(',')[0].split(':')))
-        f.close()
+            with open(self.kcConfig, "w") as f:
+                f.write("ssl.ca.location=%s/cacert.pem\nsecurity.protocol=SASL_SSL\n"
+                        "sasl.mechanism=PLAIN\nsasl.username=%s\nsasl.password="
+                        "%s\n" % tuple([self.tlsDir] + self.ul.split(',')[0].split(':')))
+
+    def writeHopConfig (self):
+        if not self.noSec:
+            username, password = self.ul.split(',')[0].split(':')
+            config = {
+                "username": username,
+                "password": password,
+                "mechanism": "SASL_SSL",
+                "ssl_ca_location": self.tlsDir
+            }
+            with open(self.hopConfig, "w") as f:
+                toml.dump(config, f)
 
     def writeKafkaConfig (self):
         kcOut  = open(self.kConfig, "w")

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -63,7 +63,9 @@ class ServerContainer (multiprocessing.Process):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s" % self.network
         command += " %s %s %s </dev/null" %  (" ".join(opts), self.cimage, cmd)
         print("COMMAND: %s" % command)
-        return subprocess.Popen([command], shell=True, env=dict(os.environ, XDG_CONFIG_PATH="/root"))
+        line = subprocess.Popen([command], shell=True, stdout=subprocess.PIPE,
+                                env=dict(os.environ, XDG_CONFIG_PATH="/root")).stdout.read()
+        return line.decode().splitlines()
 
     def runClientCommandFileInput (self, cmd, fname, opts=[]):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s " % self.network

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -63,7 +63,7 @@ class ServerContainer (multiprocessing.Process):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s" % self.network
         command += " %s %s %s </dev/null" %  (" ".join(opts), self.cimage, cmd)
         print("COMMAND: %s" % command)
-        return os.system(command)
+        return subprocess.Popen([command], shell=True, env=dict(os.environ, XDG_CONFIG_PATH="/root/shared"))
 
     def runClientCommandFileInput (self, cmd, fname, opts=[]):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s " % self.network

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -63,9 +63,8 @@ class ServerContainer (multiprocessing.Process):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s" % self.network
         command += " %s %s %s </dev/null" %  (" ".join(opts), self.cimage, cmd)
         print("COMMAND: %s" % command)
-        line = subprocess.Popen([command], shell=True, stdout=subprocess.PIPE,
-                                env=dict(os.environ, XDG_CONFIG_PATH="/root")).stdout.read()
-        return line.decode().splitlines()
+        return subprocess.Popen([command], shell=True, stdout=subprocess.PIPE,
+                                env=dict(os.environ, XDG_CONFIG_PATH="/root")).stdout.read().decode()
 
     def runClientCommandFileInput (self, cmd, fname, opts=[]):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s " % self.network

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -63,7 +63,7 @@ class ServerContainer (multiprocessing.Process):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s" % self.network
         command += " %s %s %s </dev/null" %  (" ".join(opts), self.cimage, cmd)
         print("COMMAND: %s" % command)
-        return subprocess.Popen([command], shell=True, env=dict(os.environ, XDG_CONFIG_PATH="/root/shared"))
+        return subprocess.Popen([command], shell=True, env=dict(os.environ, XDG_CONFIG_PATH="/root"))
 
     def runClientCommandFileInput (self, cmd, fname, opts=[]):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s " % self.network

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -63,8 +63,8 @@ class ServerContainer (multiprocessing.Process):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s" % self.network
         command += " %s %s %s </dev/null" %  (" ".join(opts), self.cimage, cmd)
         print("COMMAND: %s" % command)
-        return subprocess.Popen([command], shell=True, stdout=subprocess.PIPE,
-                                env=dict(os.environ, XDG_CONFIG_PATH="/root")).stdout.read().decode()
+        os.environ["XDG_CONFIG_HOME"] = "/root"
+        return os.system(command)
 
     def runClientCommandFileInput (self, cmd, fname, opts=[]):
         command  = "docker run -i -v shared:/root/shared --rm=true --network=%s " % self.network
@@ -89,7 +89,7 @@ class ServerContainer (multiprocessing.Process):
             n = n - 1
             if self.runClientCommand(command) == 0:
                   return True
-            time.sleep(1)
+            time.sleep(5*(tries - n))
         return False
 
     def terminate (self):

--- a/test/test_sec.py
+++ b/test/test_sec.py
@@ -1,11 +1,13 @@
 import TestUtils as tu
 import re
+import time
 
 def setup_module (module):
     global server
     tu.startNet("scimma-test")
     server = tu.ServerContainer(tu.testTag(), opts=["-v", "shared:/root/shared"])
     server.start()
+    time.sleep(30)
 
 def teardown_module (module):
     server.terminate()

--- a/test/test_sec.py
+++ b/test/test_sec.py
@@ -64,13 +64,12 @@ def test_okIfSslAndGoodPasswd ():
     assert(server.runClientCommand(command) == 0)
 
 def test_scimmaPublishGCN ():
-    cnf = "/root/shared/kafkacat.conf"
     brk = "kafka://%s/gcn" % server.brokerString()
     gcn = "/root/test_data/example.gcn3"
-    command = "hop publish -F %s %s %s" % (cnf, brk, gcn)
+    command = "hop publish %s %s" % (brk, gcn)
     assert(server.runClientCommand(command) == 0)
 
 def test_scimmaSubscribeGCN ():
-    cnf = "/root/shared/kafkacat.conf"
     brk = "kafka://%s/gcn" % server.brokerString()
-    command = "hop subscribe -F %s -e %s" % (cnf, brk)
+    command = "hop subscribe -s EARLIEST %s" % (brk)
+    assert(server.runClientCommand(command) == 0)

--- a/test/test_sec.py
+++ b/test/test_sec.py
@@ -1,13 +1,11 @@
 import TestUtils as tu
 import re
-import time
 
 def setup_module (module):
     global server
     tu.startNet("scimma-test")
     server = tu.ServerContainer(tu.testTag(), opts=["-v", "shared:/root/shared"])
     server.start()
-    time.sleep(30)
 
 def teardown_module (module):
     server.terminate()


### PR DESCRIPTION
This PR makes update for hop-client 0.1, including:

* Write an additional TOML-based config file for hop-client. I opted for writing both rather than modifying the previous one so that kafkacat still works without any changes.
* Update what gets installed in the client container: hop-client 0.1.
* Minor changes to config writing to use a context handler.

I haven't verified that everything works as intended, but I wanted to run this by you first to see if this looks sensible.